### PR TITLE
tcl will not receive output of yosys commands

### DIFF
--- a/cmd_tcl.in
+++ b/cmd_tcl.in
@@ -14,5 +14,9 @@ in order to avoid a name collision with the built in commands.
 If any arguments are specified, these arguments are provided to the script via
 the standard $argc and $argv variables.
 
+Note, tcl will not recieve the output of any yosys command. If the output
+of the tcl commands are needed, use the yosys command tee to redirect yosys's
+output to a temporary file.
+
 </pre>
 @footer@


### PR DESCRIPTION
This pull request is to address https://github.com/YosysHQ/yosys/issues/2980.

The documentation, as originally written, does not make it clear that yosys commands, when used within a tcl script, do not return any value to the tcl script.

This pull request notes this and offers a workaround as noted in the issue.